### PR TITLE
add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+closes #ISSUE-NO
+
+#### What does this PR do?
+
+#### Description of Task to be completed?
+
+#### How can this be manually tested?
+
+#### Any background context you want to provide?
+
+#### What is the relevant issue link?
+
+#### Screenshots (if appropriate)
+
+#### Questions:


### PR DESCRIPTION
closes #153 

#### What does this PR do?
- It provides a PR template for future PRs'. The benefit of this is the maintainer/anyone interested in a newly raised PR will have answers to relevant questions without the back n forth with whoever raised the PR

#### Description of Task to be completed?
- Add a pull request `.md` file.

#### How can this be manually tested?
- It has to be merged, Github will auto-populate new PR with the contents in this file once detected.

#### Any background context you want to provide?
- When deciding if a PR should be merged or not, you may not be clear on how to test it out, and this leads to a chain of messages(usually not instant). Adding a PR_template eliminates that blocker, by providing relevant questions you would have had to ask the PR owner before testing out the PR

#### What is the relevant issue link?
- N/A

#### Screenshots (if appropriate)
- N/A

#### Questions:
- N/A