### PR TITLE
docs: Edited the Invitation template

### DIFF
--- a/.github/ISSUE_TEMPLATE/invitation.md
+++ b/.github/ISSUE_TEMPLATE/invitation.md
@@ -7,7 +7,7 @@ assignees: eddiejaoude, mikeysan
 ---
 
 <!---
-Invitation will be sent for the GitHub Organization soon. We look forward to having you part of our community :nerd:
+Invitation will be sent for the GitHub Organization soon. We look forward to having you part of our community :nerd_face:
 Don't forget after accepting to make it public so it appears on your github profile for everyone else to see, you can do this by finding your name in the github organization list and change the dropdown to public https://github.com/orgs/EddieJaoudeCommunity/people
 Tips for practicing:
 - Customise your GitHub profile, here is a live stream on it https://www.youtube.com/watch?v=cT6GXCuS0Zo
@@ -30,4 +30,4 @@ Additional Context:
 
 <!--What do you like about this community/ why do you want to join--> 
 
-:nerd:
+:nerd_face:

--- a/.github/ISSUE_TEMPLATE/invitation.md
+++ b/.github/ISSUE_TEMPLATE/invitation.md
@@ -16,6 +16,9 @@ Tips for practicing:
 I hope that helps
 -->
 
+Please invite me to the GitHub Community Organisation.
+<!--more-specification(if any)-->
+
 <!--Some Details-->
 Name:
 
@@ -27,3 +30,4 @@ Additional Context:
 
 <!--What do you like about this community/ why do you want to join--> 
 
+:nerd:

--- a/.github/ISSUE_TEMPLATE/invitation.md
+++ b/.github/ISSUE_TEMPLATE/invitation.md
@@ -6,14 +6,24 @@ labels: 'invite me to the organisation'
 assignees: eddiejaoude, mikeysan
 ---
 
-Invitation will be sent for the GitHub Organisation soon. We look forward to having you part of our community :nerd:
-
-Don't forget after accepting to make it public so it appears on your github profile for everyone else to see, you can do this by finding your name in the github organisation list and change the dropdown to public https://github.com/orgs/EddieJaoudeCommunity/people
-
+<!---
+Invitation will be sent for the GitHub Organization soon. We look forward to having you part of our community :nerd:
+Don't forget after accepting to make it public so it appears on your github profile for everyone else to see, you can do this by finding your name in the github organization list and change the dropdown to public https://github.com/orgs/EddieJaoudeCommunity/people
 Tips for practicing:
-
 - Customise your GitHub profile, here is a live stream on it https://www.youtube.com/watch?v=cT6GXCuS0Zo
 - Practice repo, instructions how to add your name to the README in the README https://github.com/EddieJaoudeCommunity/hacktoberfest-practice
 - Remember contributing to open source is not just about code, its about collaboration, communication and adding value
-
 I hope that helps
+-->
+
+<!--Some Details-->
+Name:
+
+Discord Username(if exists): 
+<!--https://discord.gg/ErG8W36Tkm (link to our discord server)-->
+
+Additional Context:
+<!--Where did you meet Eddie?-->
+
+<!--What do you like about this community/ why do you want to join--> 
+


### PR DESCRIPTION
### What does this PR do?
 It implements the changes suggested in [#118 on the `EddieJaoudeCommunity.github.io` repo](https://github.com/EddieJaoudeCommunity/EddieJaoudeCommunity.github.io/issues/118)

#### How can this be manually tested?
By opening an invitation issue at https://github.com/Vyvy-vi/Vyvy-vi 
(I tested it there 🙂 , since issues aren't present on forks)
#### Any background context you want to provide?
I always saw the `#github` channel in the discord, getting filled with messages that contained the text that we wanted the new member to read, and rather doesn't reflect a personalised message from the user(who might be new to github). Thus, commenting out the text seems to improve the function it serves:
1- the user can read it
2- adding field columns might boost interaction(many invites seem dry, when they just include the default message)
3- A link to the server and a field to enter your discord, might encourage referencing(communities are better driven if users are synced across platforms)

#### What is the relevant issue link?
https://github.com/EddieJaoudeCommunity/EddieJaoudeCommunity.github.io/issues/118
#### Screenshots (if appropriate)
Older format:
![Screenshot 2020-11-22 at 3 23 15 AM](https://user-images.githubusercontent.com/62864373/99888342-1b3fec00-2c72-11eb-9734-8f76aaf94cf8.png)
New invite issue-format:
![Screenshot 2020-11-22 at 3 16 09 AM](https://user-images.githubusercontent.com/62864373/99888215-16c70380-2c71-11eb-960d-9fbfb174fcad.png)

#### Questions:
Does this look apt, or should more changes be made?