### PR TITLE
fix: Changed Invite label

### DIFF
--- a/.github/ISSUE_TEMPLATE/invitation.md
+++ b/.github/ISSUE_TEMPLATE/invitation.md
@@ -2,7 +2,7 @@
 name: Invitation to the GitHub Community Organization
 about: I would like to be part of the awesome community
 title: 'Please invite me to the GitHub Community Organization'
-labels: 'invite me to the organization'
+labels: invite me to the organization
 assignees: eddiejaoude, mikeysan
 ---
 

--- a/.github/ISSUE_TEMPLATE/invitation.md
+++ b/.github/ISSUE_TEMPLATE/invitation.md
@@ -2,7 +2,7 @@
 name: Invitation to the GitHub Community Organization
 about: I would like to be part of the awesome community
 title: 'Please invite me to the GitHub Community Organization'
-labels: invite me to the organization
+labels: invite me to the organisation
 assignees: eddiejaoude, mikeysan
 ---
 


### PR DESCRIPTION
closes #505 

#### What does this PR do?
Enables all Invitation Issues to have the label 'invite me to the organisation'.

#### How can this be manually tested?
By creating an invitation issue.

