### PR TITLE
Fix: Issue #469

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Community Support
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 [![Discord](https://img.shields.io/discord/699608417039286293?style=flat-square)](https://discord.gg/jZQs6Wu)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 Raise an issue to join the EddieJaoudeCommunity GitHub community.


### PR DESCRIPTION
closes #469 

#### What does this PR do?
Removes the all-contributors badge since GitHub shows the list itself, and it doesn't work anyways.

#### Description of Task to be completed?
Removal of redundancy. Task is completed.

#### How can this be manually tested?
By reading the README.md

#### What is the relevant issue link?
https://github.com/EddieJaoudeCommunity/support/issues/469

#### Screenshots (if appropriate)
Screenshots are available at the issue.

#### Questions:
Shall we add one other badge? Something that depicts how many member the Discord Server has?