### PR TITLE
Automate organisation invite

### DIFF
--- a/.github/ISSUE_TEMPLATE/invitation.md
+++ b/.github/ISSUE_TEMPLATE/invitation.md
@@ -3,9 +3,7 @@ name: Invitation to the GitHub Community Organization
 about: I would like to be part of the awesome community
 title: 'Please invite me to the GitHub Community Organization'
 labels: invite me to the organisation
-assignees: eddiejaoude, mikeysan
 ---
-
 
 <!---
 Invitation will be sent for the GitHub Organization soon. We look forward to having you part of our community :nerd_face:
@@ -17,18 +15,21 @@ Tips for practicing:
 I hope that helps
 -->
 
-Please invite me to the GitHub Community Organisation. 
+Please invite me to the GitHub Community Organisation.
+
 <!--more-specification(if any)-->
 
 <!--Some Details-->
+
 - #### Name:
 
-- #### Discord Username(if exists): 
+- #### Discord Username(if exists):
+
 <!--https://discord.gg/ErG8W36Tkm (link to our discord server)-->
 
 - #### Additional Context:
 <!--Where did you meet Eddie?-->
 
-<!--What do you like about this community/ why do you want to join--> 
+<!--What do you like about this community/ why do you want to join-->
 
 :nerd_face:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,16 @@
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  automate_invite:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invite on label
+        uses: vj-abigo/invite-on-label@v1.1
+        with:
+          organization: EddieJaoudeCommunity
+          label: invite me to the organisation
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
#### What does this PR do?
automates organisation invitation and removed assignes in ISSUE_TEMPLATE on `invitation.md`

**NOTE:** create a repository secret called `ACCESS_TOKEN` and as a value provide a GitHub [personal access token](https://github.com/settings/tokens) with the scope of _`admin:org`_